### PR TITLE
Fix deprecated `Block::zero()`

### DIFF
--- a/src/wire.rs
+++ b/src/wire.rs
@@ -26,7 +26,7 @@ pub enum Wire {
 
 impl std::default::Default for Wire {
     fn default() -> Self {
-        Wire::Mod2 { val: Block::zero() }
+        Wire::Mod2 { val: Block::default() }
     }
 }
 
@@ -94,7 +94,7 @@ impl Wire {
     pub fn zero(q: u16) -> Self {
         match q {
             1 => panic!("[wire::zero] mod 1 not allowed!"),
-            2 => Wire::Mod2 { val: Block::zero() },
+            2 => Wire::Mod2 { val: Block::default() },
             _ => Wire::ModN {
                 q,
                 ds: vec![0; util::digits_per_u128(q)],
@@ -179,7 +179,7 @@ impl Wire {
         match self {
             Wire::Mod2 { val } => {
                 if c & 1 == 0 {
-                    *val = Block::zero();
+                    *val = Block::default();
                 }
             }
 
@@ -424,13 +424,13 @@ mod tests {
         let hashes = crossbeam::scope(|scope| {
             let hs = ws
                 .iter()
-                .map(|w| scope.spawn(move |_| w.hash(Block::zero())))
+                .map(|w| scope.spawn(move |_| w.hash(Block::default())))
                 .collect_vec();
             hs.into_iter().map(|h| h.join().unwrap()).collect_vec()
         })
         .unwrap();
 
-        let should_be = ws.iter().map(|w| w.hash(Block::zero())).collect_vec();
+        let should_be = ws.iter().map(|w| w.hash(Block::default())).collect_vec();
 
         assert_eq!(hashes, should_be);
     }


### PR DESCRIPTION
Hi! It seems that `Block::zero()` is deprecated in https://github.com/amaloz/scuttlebutt, so I made a quick PR to change all uses of it to `Block::default()`.

There's also currently a couple of functions that are used only in tests, namely `utils::u128_from_bits` and `utils::from_mixed_radix`; I can make a separate PR to `#[cfg(test)]` those (unless you have plans to use them outside tests).

Thanks for your great library!