### PR TITLE
Add optional support for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 
 [features]
 nightly = ["rand/nightly", "scuttlebutt/nightly"]
+serde1 = ["serde", "scuttlebutt/serde"]
 
 [dependencies]
 base_conversion = { path = "base_conversion" }
@@ -23,6 +24,7 @@ itertools = "0.8.0"
 rand = "0.6.5"
 regex = "1.1.7"
 scuttlebutt = { git = "https://github.com/GaloisInc/scuttlebutt", tag = "0.3.2" }
+serde = { version = "1", features = ["derive"], optional = true } 
 
 [dev-dependencies]
 criterion = "0.2.11"

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -7,9 +7,9 @@ use crate::fancy::{BinaryBundle, CrtBundle, Fancy, FancyInput, HasModulus};
 use crate::informer::InformerVal;
 use itertools::Itertools;
 use std::collections::HashMap;
-
 /// The index and modulus of a gate in a circuit.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct CircuitRef {
     pub(crate) ix: usize,
     pub(crate) modulus: u16,
@@ -29,6 +29,7 @@ impl HasModulus for CircuitRef {
 
 /// Static representation of the type of computation supported by fancy garbling.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Circuit {
     pub(crate) gates: Vec<Gate>,
     pub(crate) gate_moduli: Vec<u16>,
@@ -41,6 +42,7 @@ pub struct Circuit {
 
 /// The most basic types of computation supported by fancy garbling.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) enum Gate {
     GarblerInput {
         id: usize,

--- a/src/static.rs
+++ b/src/static.rs
@@ -22,6 +22,7 @@ use std::rc::Rc;
 ///
 /// Uses `Evaluator` under the hood to actually implement the evaluation.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct GarbledCircuit {
     blocks: Vec<Block>,
 }
@@ -102,6 +103,7 @@ pub fn garble(c: &mut Circuit) -> Result<(Encoder, GarbledCircuit), GarblerError
 
 /// Encode inputs statically.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Encoder {
     garbler_inputs: Vec<Wire>,
     evaluator_inputs: Vec<Wire>,

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -7,6 +7,7 @@ use scuttlebutt::{Block, AES_HASH};
 
 /// The core wire-label type.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum Wire {
     /// Representation of a `mod-2` wire.
     Mod2 {


### PR DESCRIPTION
It would be useful for my project to have optional serde support (I send garbled circuits and wires over the network). This PR achieves this by basically undoing https://github.com/GaloisInc/fancy-garbling/commit/f791b9753685f63289b6f4063cbb2468826bb750.